### PR TITLE
Add additional tooling sections

### DIFF
--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -23,7 +23,8 @@
   summary: Mock server that implements the API Blueprint specification, with a few
     extras rolled in. Usable as both a standalone server as well as a Node.js module.
   url: https://www.npmjs.com/package/drakov
-  tags: []
+  tags:
+    - mock servers
 - name: cURL trace parser
   summary: Record HTTP communication directly in the API Blueprint format.
   url: https://github.com/apiaryio/curl-trace-parser
@@ -36,7 +37,8 @@
 - name: Iglo
   summary: Generate static HTML documentation from API Blueprint.
   url: https://github.com/subosito/iglo
-  tags: []
+  tags:
+    - renderers
 - name: Sublime Text plugin
   summary: API Blueprint & MSON syntax highlighting, live validation and parsing in
     your favorite text editor.
@@ -62,7 +64,8 @@
   summary: Render HTML from API blueprint files, with support for custom themes. Executable
     and asynchronous Node.js library.
   url: https://github.com/danielgtaylor/aglio
-  tags: []
+  tags:
+    - renderers
 - name: Matter Compiler
   summary: Matter Compiler is an API Blueprint AST to API Blueprint conversion tool.
     It composes an API blueprint from its serialized AST media-type.
@@ -71,26 +74,31 @@
 - name: API-Mock
   summary: Generate a simple, fast mock server from an API Blueprint.
   url: https://github.com/localmed/api-mock
-  tags: []
+  tags:
+    - mock servers
 - name: API Blueprint Mock Server
   summary: Run a simple, fast mock server in Java from an API Blueprint. Plans for
     Android support in the future.
   url: https://bitbucket.org/outofcoffee/api-blueprint-mockserver
-  tags: []
+  tags:
+    - mock servers
 - name: Blueman
   summary: Convert an API Blueprint into a Postman collection.
   url: http://git.io/blueman
-  tags: []
+  tags:
+    - converters
 - name: apiary2postman
   summary: Convert an API Blueprint into a Postman collection, supports fetching from
     Apiary API and reading from files or stdin.
   url: https://github.com/thecopy/apiary2postman
-  tags: []
+  tags:
+    - converters
 - name: Blueprint docify
   summary: Add your API spec in the root of your repo and push! It will make great
     API docs for each branch, which are available at http://org.github.io/repo/branch
   url: https://github.com/renewablefunding/blueprint-docify
-  tags: []
+  tags:
+    - renderers
 - name: CCLRequestReplay
   summary: Write your iOS and OS X tests directly to your API specification without
     writing any extra code.
@@ -108,17 +116,20 @@
   summary: This tool allows you to record, specify, mock and test your web APIs. You
     can import existing API Blueprints into this tool.
   url: http://vrest.io/
-  tags: []
+  tags:
+    - testing
 - name: Sandbox
   summary: Simplify your testing. Quick and easy web API mocks, generated from API
     Blueprint, instant deploy, collaborative build, and debugging tools for API integration.
   url: https://getsandbox.com
-  tags: []
+  tags:
+    - testing
 - name: Vigia
   summary: Flexible and scalable tool to provide RSpec integration tests using definition
     files such as API Blueprint
   url: https://github.com/nogates/vigia
-  tags: []
+  tags:
+    - testing
 - name: Paw
   summary: A fully-featured HTTP client for the Mac featuring API Blueprint integration
     via extensions.
@@ -133,7 +144,8 @@
   summary: Host your API Blueprints inside your ASP.net solution using this built-in
     mock server inside an encapsulated HTTP module.
   url: https://github.com/BishoyDemian/api-blueprint-aspnet-host
-  tags: []
+  tags:
+    - mock servers
 - name: grape-apiary
   summary: Generate API blueprints automatically from your already defined Grape api
     endpoints.
@@ -153,7 +165,8 @@
     of your Rack (Rails, Sinatra, Grape...) applications API against their blueprints,
     with Dredd, in Ruby.
   url: https://github.com/gonzalo-bulnes/dredd-rack
-  tags: []
+  tags:
+    - testing
 - name: Hyperdrive
   summary: Hyperdrive allows you to build Swift applications that can evolve at run-time
     powered by API Blueprint.
@@ -179,11 +192,13 @@
 - name: Bluepaste
   summary: API Blueprint pastebin service.
   url: https://bluepaste.herokuapp.com
-  tags: []
+  tags:
+    - renderers
 - name: swagger2blueprint
   summary: Convert Swagger API descriptions into API Blueprint.
   url: https://github.com/apiaryio/swagger2blueprint
-  tags: []
+  tags:
+    - converters
 - name: Gelato.io
   summary: Import your API Blueprint and get hosted documentation, with an API Explorer,
     Developer Registration, proper Search and more!
@@ -195,11 +210,14 @@
     to detect several types of errors that may exist in our API descritpion. Minor
     errors are automatically fixed through our a linting process.
   url: https://apitransformer.com/
-  tags: []
+  tags:
+    - converters
 - name: Apib::MockServer
   summary: Create a mock server for your Ruby tests based on API Blueprints.
   url: https://github.com/karnov/apib-mock_server
-  tags: []
+  tags:
+    - testing
+    - mock servers
 - name: Blueprint API Validator
   summary: Ensure your Blueprint API files conform to a standard. This plugin validates
     the format, JSON bodies and Schema in your Blueprint spec files.

--- a/source/tools.html.erb
+++ b/source/tools.html.erb
@@ -11,7 +11,7 @@ title: API Blueprint Tools
     <ul class="nav nav-pills">
         <li class="active" data-id="all"><a href="#">Tools</a></li>
         <% tool_tags.each do |tag| %>
-            <li data-id="<%= tag %>"><a href="#"><%= tag.capitalize %></a></li>
+            <li data-id="<%= tag.gsub(' ','-') %>"><a href="#"><%= tag.capitalize %></a></li>
         <% end %>
     </ul>
 </div>
@@ -19,7 +19,7 @@ title: API Blueprint Tools
 <div role="main">
     <div id="tools">
         <% data.tools.each do |tool| %>
-            <div class="row tool <%= tool.tags.map{|tag| "tool-#{tag}" }.join(' ') %>">
+            <div class="row tool <%= tool.tags.map{|tag| "tool-#{tag.gsub(' ','-')}" }.join(' ') %>">
                 <div class="col-md-5">
                     <h3><a href="<%= tool.url %>"><%= tool.name %></a></h3>
 


### PR DESCRIPTION
## Changes

* Add sections to the tooling page for:
  * **Mock servers** - creates a local web server from blueprint requests and responses
  * **Renderers** - hosts blueprints as HTML or other formats
  * **Converters** - converts blueprints to/from some other format (generally HTML) 
* Apply sections to existing tools in `tools.yaml`

![sections](https://cloud.githubusercontent.com/assets/333454/12403125/b7a77f98-be29-11e5-8b4c-98bdb5735fb0.png)

## Questions

1. Section naming. Do these names seem clear and make sense?
2. Should more tags apply to the Apiary tool listing? For example, it overlaps with Dredd but also includes testing/mock servers, rendering, et cetera

