### PR TITLE
Use the locked version of bundler in Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,10 @@ checkout:
     - git submodule init
     - git submodule update
 
+dependencies:
+  pre:
+    - gem install bundler -v "$(cat Gemfile.lock | tail -n 1 | tr -d '[[:space:]]')"
+
 test:
   override:
     - /bin/true


### PR DESCRIPTION
This pull request ensures that the version of bundler used in CI is the same as the version used to develop apiblueprint.org by utilising the version in the lock file.

```
BUNDLED WITH
   1.11.2
```

Without this change, Circle CI was using an older version, and subsequently causing the website to no longer automatically deploy. This is because the `Gemfile.lock` file was being updated with a different version. The deploy process will not let you deploy  when you have local changes thus failing.

```
Changes not staged for commit:
	modified:   ../Gemfile.lock
```