### PR TITLE
Update Ruby and Rouge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gem 'middleman-rouge'
 gem 'middleman-livereload'
 gem 'middleman-deploy'
 
-gem 'rouge', git: 'https://github.com/jneen/rouge'
+gem 'rouge'
 gem 'bootstrap-sass', '~> 3.3'
 gem 'bh', '~> 1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: https://github.com/jneen/rouge
-  revision: 53f00b8686921553e70c62403c14a5644f828e95
-  specs:
-    rouge (1.10.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -155,6 +149,7 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.3.4)
+    rouge (2.0.1)
     sass (3.4.21)
     sprockets (2.12.4)
       hike (~> 1.2)
@@ -188,7 +183,7 @@ DEPENDENCIES
   middleman-deploy
   middleman-livereload
   middleman-rouge
-  rouge!
+  rouge
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.2.3
+    version: 2.3.1
 
 checkout:
   post:


### PR DESCRIPTION
- Updates to Ruby 2.3.1
- Updates to Rouge release instead of installing from Git. The API Blueprint lexer was released in Rouge.