### PR TITLE
Fix a YAML error in the tools section and lint the tools on CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,10 @@ task :serve do
   sh 'bundle exec middleman server'
 end
 
+desc 'Validate the tools section'
+task 'validate-tools' do
+  require 'yaml'
+  YAML.load_file('data/tools.yaml')
+end
+
 task :default => :serve

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
 
 test:
   override:
-    - /bin/true
+    - rake validate-tools
 
 deployment:
   production:

--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -265,4 +265,4 @@
 - name: doc-proxy
   summary: Node server to generate documentation.md file for all the endpoints supported by your server
   url: https://github.com/sandeep89/doc-proxy
-  tags:[]
+  tags: []


### PR DESCRIPTION
As reported in #59, there is a YAML syntax error in our tools list. This pull request fixes that error and adds parsing the file during CI so that we will catch errors in PRs in the future.

The following error will be emitted when the tools.yml has a syntax error:

```shell
$ rake validate-tools
rake aborted!
Psych::SyntaxError: (data/tools.yaml): could not find expected ':' while scanning a simple key at line 268 column 3
```