### PR TITLE
Added snowboard to tools section

### DIFF
--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -277,3 +277,9 @@
   tags:
     - parsers
     - renderers
+- name: Snowboard
+  summary: Render HTML documentation from API blueprint. Support custom templates. Executable and Golang library.
+  url: https://github.com/subosito/snowboard
+  tags:
+    - parsers
+    - renderers

--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -34,10 +34,11 @@
   url: https://github.com/playround/rspec_api_blueprint
   tags:
     - testing
-- name: Iglo
-  summary: Generate static HTML documentation from API Blueprint.
-  url: https://github.com/subosito/iglo
+- name: Snowboard
+  summary: Render HTML documentation from API blueprint. Support custom templates. Executable and Golang library.
+  url: https://github.com/subosito/snowboard
   tags:
+    - parsers
     - renderers
 - name: Sublime Text plugin
   summary: API Blueprint & MSON syntax highlighting, live validation and parsing in
@@ -274,12 +275,6 @@
 - name: MSONGenerator
   summary: Generate MSON from JSON. (Site may be first time long responds)
   url: https://msongenerator.herokuapp.com/
-  tags:
-    - parsers
-    - renderers
-- name: Snowboard
-  summary: Render HTML documentation from API blueprint. Support custom templates. Executable and Golang library.
-  url: https://github.com/subosito/snowboard
   tags:
     - parsers
     - renderers


### PR DESCRIPTION
Snowboard is my (another ^^) attempt to provides pleasant experience when working with API blueprint.

Snowboard goal is provides single binary application, so anyone can just download it and start producing documentation, while allows developer to create and use custom documentation template.

https://github.com/subosito/snowboard is next version of [Iglo](https://github.com/subosito/iglo). Both written using Golang. The main difference is Iglo use drafter command line and AST, while snowboard  using drafter library via cgo and Refract.
