### PR TITLE
Added docprint

### DIFF
--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -278,3 +278,9 @@
   tags:
     - parsers
     - renderers
+- name: docprint
+  summary: Generate Clean Static HTML documentation from API Blueprint file. Provides waypoints, attributes and multiple language code snippets.
+  url: https://github.com/swathysubhash/docprint
+  tags:
+    - parsers
+    - renderers

--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -282,5 +282,4 @@
   summary: Generate Clean Static HTML documentation from API Blueprint file. Provides waypoints, attributes and multiple language code snippets.
   url: https://github.com/swathysubhash/docprint
   tags:
-    - parsers
     - renderers


### PR DESCRIPTION
docprint generates Clean Static HTML documentation from API Blueprint file. Provides waypoints, attributes and multiple language code snippets.