### PR TITLE
Add Draughtsman to tools

### DIFF
--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -312,3 +312,8 @@
   url: https://github.com/PhillippOhlandt/pmtoapib
   tags:
     - converters
+- name: Draughtsman
+  summary: API Blueprint Parser for Python 3
+  url: https://github.com/kylef/draughtsman
+  tags:
+    - parsers


### PR DESCRIPTION
Draughtsman  is an API Blueprint Parser for Python 3. Draughtsman is a Python binding for the API Blueprint parser drafter.