### PR TITLE
Add Dox to tools

### DIFF
--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -342,3 +342,9 @@
   url: https://github.com/KittyHeaven/blue_bird
   tags:
     - testing
+- name: Dox
+  summary: Generate API Blueprint from RSpec tests in a Rails application.
+  url: https://github.com/infinum/dox
+  tags:
+    - testing
+    - tools


### PR DESCRIPTION
Dox is a Ruby gem, it generates API documentation from RSpec controller/request specs in a Rails application. It formats the tests output in the API Blueprint format.

https://github.com/infinum/dox