### PR TITLE
Validate tools against a schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ gem 'middleman-deploy', '2.0.0.pre.alpha'
 gem 'bootstrap-sass', '~> 3.3'
 gem 'bh', '~> 1.3'
 gem 'redcarpet'
+
+gem 'json-schema'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
     hashie (3.5.5)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
+    json-schema (2.8.0)
+      addressable (>= 2.4)
     kramdown (1.13.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -156,6 +158,7 @@ PLATFORMS
 DEPENDENCIES
   bh (~> 1.3)
   bootstrap-sass (~> 3.3)
+  json-schema
   middleman
   middleman-deploy (= 2.0.0.pre.alpha)
   middleman-livereload
@@ -163,4 +166,4 @@ DEPENDENCIES
   redcarpet
 
 BUNDLED WITH
-   1.13.6
+   1.15.4

--- a/Rakefile
+++ b/Rakefile
@@ -5,8 +5,44 @@ end
 
 desc 'Validate the tools section'
 task 'validate-tools' do
+  require 'bundler/setup'
   require 'yaml'
-  YAML.load_file('data/tools.yaml')
+  require 'json-schema'
+
+  tools = YAML.load_file('data/tools.yaml')
+
+  schema = {
+    type: 'array',
+    items: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+        summary: {
+          type: 'string',
+        },
+        url: {
+          type: 'string',
+          format: 'uri',
+        },
+        tags: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+      },
+      required: [
+        'name',
+        'summary',
+        'url',
+        'tags',
+      ]
+    }
+  }
+
+  JSON::Validator.validate!(schema, tools)
 end
 
 task :default => :serve


### PR DESCRIPTION
I noticed in a PR that the tags section was missing (https://github.com/apiaryio/apiblueprint.org/pull/89#discussion_r143173168), probably good idea to validate the whole tools section against a schema which this PR does.