### PR TITLE
remove duplicate tools

### DIFF
--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -347,7 +347,6 @@
   url: https://github.com/infinum/dox
   tags:
     - testing
-    - tools
 - name: esplanade
   summary: Validate requests and responses against API Blueprint specifications for Ruby.
   url: https://github.com/funbox/esplanade


### PR DESCRIPTION
On the page there were second tools
https://apiblueprint.org/tools.html#tools