### PR TITLE
Convert postman collection to api-blueprint markup

### DIFF
--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -83,6 +83,12 @@
   url: http://git.io/blueman
   tags:
     - converters
+
+- name: postman2apiary
+  summary: Tool for generating Blueprint API markup or the Apiary API from a Postman collection. 
+  url: https://github.com/p8ul/postman2apiary
+  tags:
+     - converters
 - name: apiary2postman
   summary: Convert an API Blueprint into a Postman collection, supports fetching from
     Apiary API and reading from files or stdin.


### PR DESCRIPTION
### What this PR do
- Adds a tool for generating Blueprint API markup or the Apiary API from a Postman collection.

### Installation 
     git clone https://github.com/p8ul/postman2apiary.git
     cd app
### Usage
    CLI application Application takes three arguments.
     USAGE: $ python run.py [postman.json-file] [output-file.apid]

     postman.json-file: JSON file exported from Postman collection
     output-file.apid: Name of your API markup file to be generated.
