### PR TITLE
Update snowboard description in tools

### DIFF
--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -35,7 +35,7 @@
   tags:
     - testing
 - name: Snowboard
-  summary: Render HTML documentation from API blueprint. Support custom templates. Executable and Golang library.
+  summary: Render HTML documentation from API blueprint. Support custom templates.
   url: https://github.com/bukalapak/snowboard
   tags:
     - parsers


### PR DESCRIPTION
Snowboard seems to have been rewritten in JavaScript, remove reference to Golang.