### PR TITLE
Update installation instructions for CMake

### DIFF
--- a/source/developers.html.md
+++ b/source/developers.html.md
@@ -45,13 +45,13 @@ Every Refract element may have 4 attributes, the element name, Refract specific 
 
 ### Using the command line tool
 
-1. Get Drafter command line tool
+1. Get Drafter command line tool, for macOS using [Homebrew](https://brew.sh/):
 
     ```sh
     $ brew install drafter
     ```
 
-    Build notes for [Linux](https://github.com/apiaryio/drafter#drafter-command-line-tool) and [Windows](https://github.com/apiaryio/drafter/wiki/Building-on-Windows).
+    See our [installation instructions for other platforms](https://github.com/apiaryio/drafter#installation)
 
 2. Parse API Blueprint into the Refract API Description namespace:
 
@@ -142,15 +142,7 @@ $ curl -X POST
 
 ### Using the native parser interface (C/C++)
 
-1. Build [Drafter](https://github.com/apiaryio/drafter)
-
-    ```sh
-    $ ./configure
-    $ make
-    ```
-
-    See full [build instructions](https://github.com/apiaryio/drafter#build)
-
+1. Install [Drafter](https://github.com/apiaryio/drafter)
 2. Parse your API Blueprint
 
     ```c


### PR DESCRIPTION
This updates the installation instructions on the website for CMake, instead of repeating the detailed instructions I've linked to them (https://github.com/apiaryio/drafter/pull/723). I've removed mentions of specific platform (Linux), the instructions work on Windows too (and possible BSD's although that is not tested).