### PR TITLE
(chore) drafter c api code example to match drafter@v5.0.0-rc.1

### DIFF
--- a/source/developers.html.md
+++ b/source/developers.html.md
@@ -155,12 +155,14 @@ $ curl -X POST
       "\n"
       "      Hello World!\n";
 
-    drafter_options options;
-    options.format = DRAFTER_SERIALIZE_JSON;
-    options.sourcemap = true;
+    drafter_parse_options* pOpts = drafter_init_parse_options();
+    drafter_set_name_required(pOpts);
+
+    drafter_serialize_options* sOpts = drafter_init_serialize_options();
+    drafter_set_format(sOpts, DRAFTER_SERIALIZE_JSON);
 
     char *result = NULL;
-    if (drafter_parse_blueprint_to(blueprint, &result, options) == 0) {
+    if (DRAFTER_OK == drafter_parse_blueprint_to(blueprint, &result, pOpts, sOpts)) {
         printf("%s\n", result);
         free(result);
     }


### PR DESCRIPTION
Updated C code example in developers section to match breaking C API changes introduced in https://github.com/apiaryio/drafter/pull/766 .