### PR TITLE
Updating tools section

### DIFF
--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -375,8 +375,8 @@
   url: https://github.com/Dmitiry1921/postman2apiary
   tags:
     - converters
-- name: Blueprint Dash
-  summary: An API Blueprint playground for new people to experiment on
-  url: https://blueprint-dash.surge.sh/
+- name: BlueprintStack
+  summary: An awesome API blueprint playground for new people to experiment on.
+  url: https://blueprintstack.io
   tags:
     - editors


### PR DESCRIPTION
Blueprint Dash now became BlueprintStack (https://blueprintstack.io) with more features for new people to experiment with the API blueprint spec.