### PR TITLE
Change summary and url for fitting and esplanade libraries

### DIFF
--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -313,8 +313,8 @@
   tags:
     - parsers
 - name: fitting
-  summary: RSpec matchers to validate Rails controller responses against API Blueprint document during controller tests.
-  url: https://github.com/funbox/fitting
+  summary: Library add improve test log for RSpec and WebMock, validate its according to API Blueprint and Open API, show the documentation coverage with log.
+  url: https://github.com/matchtechnologies/fitting
   tags:
     - testing
 - name: mson-to-schemas
@@ -349,7 +349,7 @@
     - testing
 - name: esplanade
   summary: Validate requests and responses against API Blueprint specifications for Ruby.
-  url: https://github.com/funbox/esplanade
+  url: https://github.com/matchtechnologies/esplanade
   tags: []
 - name: apiaryio
   summary: Node.JS CLI tool for publishing API Blueprint to apiary.


### PR DESCRIPTION
Hello, we are transferring the fitting and esplanade repositories and would like to update the information